### PR TITLE
Bug 949012 - Nexus 4 build scripts/configuration should correctly set GA...

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -28,6 +28,10 @@ DEVICE_PACKAGE_OVERLAYS := device/lge/mako/overlay
 PRODUCT_AAPT_CONFIG := normal hdpi xhdpi
 PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
+# Gaia currently needs to specify the default scale value manually or pictures
+# with correct resolution will not be applied.
+GAIA_DEV_PIXELS_PER_PX := 1.5
+
 PRODUCT_PACKAGES := \
 	lights.msm8960
 

--- a/full_mako.mk
+++ b/full_mako.mk
@@ -33,3 +33,7 @@ PRODUCT_RESTRICT_VENDOR_FILES := true
 # Inherit from hardware-specific part of the product configuration
 $(call inherit-product, device/lge/mako/device.mk)
 $(call inherit-product-if-exists, vendor/lge/mako/device-vendor.mk)
+
+# Gaia currently needs to specify the default scale value manually or pictures
+# with correct resolution will not be applied.
+GAIA_DEV_PIXELS_PER_PX := 1.5

--- a/full_mako.mk
+++ b/full_mako.mk
@@ -33,7 +33,3 @@ PRODUCT_RESTRICT_VENDOR_FILES := true
 # Inherit from hardware-specific part of the product configuration
 $(call inherit-product, device/lge/mako/device.mk)
 $(call inherit-product-if-exists, vendor/lge/mako/device-vendor.mk)
-
-# Gaia currently needs to specify the default scale value manually or pictures
-# with correct resolution will not be applied.
-GAIA_DEV_PIXELS_PER_PX := 1.5


### PR DESCRIPTION
Bug 949012 - Nexus 4 build scripts/configuration should correctly set GAIA_DEV_PIXELS_PER_PX
