### PR TITLE
Bug 1086712 - Don't bound adb connection on boot with N4/N5. r=jld

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -265,9 +265,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 	ro.qc.sensors.wl_dis=true \
 	ro.qualcomm.sensors.smd=true
 
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
-	persist.sys.usb.config=mtp
-
 # for Gecko
 PRODUCT_PROPERTY_OVERRIDES += \
        ro.moz.has_home_button=0


### PR DESCRIPTION
Remove persist.sys.usb.config altogether.

build/tools/post_process_props.py will make it be "none"
